### PR TITLE
Update base-image-url-ca-gui

### DIFF
--- a/.github/workflows/build_img_ca_gui.yml
+++ b/.github/workflows/build_img_ca_gui.yml
@@ -52,7 +52,7 @@ jobs:
           CONSTRAINTS: "https://github.com/OpenVoiceOS/ovos-releases/raw/refs/heads/main/constraints-alpha.txt"
           MYCROFT_CONFIG_FILES: "mycroft.conf,mycroft_gui.conf,mycroft_ca.conf"
         with:
-          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-catalan-bookworm-arm64-lite-2024-11-28/raspOVOS-catalan-bookworm-arm64-lite.img.xz
+          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-catalan-bookworm-arm64-lite-2024-12-01/raspOVOS-catalan-bookworm-arm64-lite.img.xz
           image-path: raspOVOS-catalan-GUI-bookworm-arm64-lite.img
           compress-with-xz: true
           shrink: true


### PR DESCRIPTION
This PR updates the base-image-url in `build_img_ca_gui.yml` to reflect the latest release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the base image URL for the image building process to a more recent date.
	- Maintained the existing workflow structure for building and managing releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->