### PR TITLE
Update base-image-url-headless

### DIFF
--- a/.github/workflows/build_img.yml
+++ b/.github/workflows/build_img.yml
@@ -52,7 +52,7 @@ jobs:
           HOSTNAME: "raspOVOS"
           CONSTRAINTS: "https://github.com/OpenVoiceOS/ovos-releases/raw/refs/heads/main/constraints-alpha.txt"
         with:
-          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-NO-OVOS-bookworm-arm64-lite-2024-12-03/raspOVOS-NO-OVOS-bookworm-arm64-lite.img.xz
+          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-NO-OVOS-bookworm-arm64-lite-2024-12-04/raspOVOS-NO-OVOS-bookworm-arm64-lite.img.xz
           image-path: raspOVOS-bookworm-arm64-lite.img
           compress-with-xz: true
           shrink: true


### PR DESCRIPTION
This PR updates the base-image-url in `build_img.yml` to reflect the latest release.