### PR TITLE
Update base-image-url-ca

### DIFF
--- a/.github/workflows/build_img_ca.yml
+++ b/.github/workflows/build_img_ca.yml
@@ -53,7 +53,7 @@ jobs:
           CONSTRAINTS: "https://github.com/OpenVoiceOS/ovos-releases/raw/refs/heads/main/constraints-alpha.txt"
           MYCROFT_CONFIG_FILES: "mycroft.conf,mycroft_ca.conf"
         with:
-          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-bookworm-arm64-lite-2024-12-11/raspOVOS-bookworm-arm64-lite.img.xz
+          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-bookworm-arm64-lite-2024-12-15/raspOVOS-bookworm-arm64-lite.img.xz
           image-path: raspOVOS-catalan-bookworm-arm64-lite.img
           compress-with-xz: true
           shrink: true


### PR DESCRIPTION
This PR updates the base-image-url in `build_img_ca.yml` to reflect the latest release.