### PR TITLE
Update base-image-url-eu

### DIFF
--- a/.github/workflows/build_img_eu.yml
+++ b/.github/workflows/build_img_eu.yml
@@ -53,7 +53,7 @@ jobs:
           CONSTRAINTS: "https://github.com/OpenVoiceOS/ovos-releases/raw/refs/heads/main/constraints-alpha.txt"
           MYCROFT_CONFIG_FILES: "mycroft.conf,mycroft_eu.conf"
         with:
-          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-bookworm-arm64-lite-2024-12-15/raspOVOS-bookworm-arm64-lite.img.xz
+          base-image-url: https://github.com/TigreGotico/raspOVOS/releases/download/raspOVOS-bookworm-arm64-lite-2024-12-19/raspOVOS-bookworm-arm64-lite.img.xz
           image-path: raspOVOS-basque-bookworm-arm64-lite.img
           compress-with-xz: true
           shrink: true


### PR DESCRIPTION
This PR updates the base-image-url in `build_img_eu.yml` to reflect the latest release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the base image URL for the Raspberry Pi image, now pointing to a new image file dated 2024-12-19.
- **Chores**
	- Maintained the overall structure and functionality of the workflow without changes to control flow or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->